### PR TITLE
解决了用户态App测试内存溢出时出现的问题。

### DIFF
--- a/components/lwp/arch/arm/cortex-m4/lwp_rvds.S
+++ b/components/lwp/arch/arm/cortex-m4/lwp_rvds.S
@@ -365,6 +365,7 @@ syscall_entry   PROC
     ENDP
 
 ;MPU保护功能 需要微调汇编程序
+;需要将权限转入特权级!
 MemManage_Handler PROC
     EXPORT  MemManage_Handler
     IMPORT  MemManage_Main
@@ -374,18 +375,29 @@ MemManage_Handler PROC
     ITE     EQ
     MRSEQ   R0, MSP
     MRSNE   R0, PSP
-
+    MOV     R3, R0
     STMFD   R0!, {R4-R11}   ;push
+
+    
+
     STR     LR, [R0,#-4]!
 
     MRS     R1, CONTROL
     STR     R1, [R0,#-4]!
     STR     LR, [R0,#-4]!
     PUSH    {LR}
+    MOV     R0, R3
 
     BL  MemManage_Main
     ;POP     {LR}
     ;B   .
+
+
+    ; set to thread-privilege mode.
+    MRS     R3, CONTROL
+    BIC     R3, R3, #0x01
+    ORR     R3, R3, #0x02
+    MSR     CONTROL, R3
 
 
     LDR     LR, [SP],   #4


### PR DESCRIPTION
## 解决思路：
在用户态下触发了内存保护，但在线程级下仍处于非特权级，无法执行中止用户态进程的操作，导致出错。

## 效果：
![image](https://user-images.githubusercontent.com/30559085/98931063-78bc9600-2518-11eb-860c-a64e0c1fd87e.png)

## 反思：
没有提前编写文档，导致在编程时思路较为混乱。以后的项目最好按照技术框架来编程。
