### PR TITLE
修复svc_exit在线程模式下改变运行模式的权力级别导致的MPU保护。

### DIFF
--- a/bsp/stm32/stm32l475-atk-pandora/applications/mpu.c
+++ b/bsp/stm32/stm32l475-atk-pandora/applications/mpu.c
@@ -34,7 +34,6 @@ int MPU_Set_Protection(rt_uint32_t baseaddr, rt_uint32_t size, rt_uint32_t rnum,
 static int MPU_Init(void)
 {
 
-    //MPU_Set_Protection(0x20000000, MPU_REGION_SIZE_16KB, MPU_REGION_NUMBER0, MPU_REGION_FULL_ACCESS);
     //MPU_Set_Protection(0x40000000, MPU_REGION_SIZE_512MB, MPU_REGION_NUMBER2, MPU_REGION_FULL_ACCESS);
     //HAL_NVIC_SetPriority(PendSV_IRQn, 0, 2);
     //HAL_NVIC_SetPriority(MemoryManagement_IRQn, 1, 2);
@@ -95,7 +94,7 @@ rt_err_t exception_handle(struct exception_stack_frame *context)
         return -1;
     }else{
         //内核发生错误 系统终止 无法挽回
-        LOG_E("thread:%s hard fault in kernel",thread);
+        LOG_E("thread:%s memmanage fault in kernel",thread);
         rt_hw_interrupt_enable(level);
         return 0;
     }
@@ -162,6 +161,7 @@ int mpu_test(int argc, char **argv)
             rt_thread_startup(tid1);
 
     }else{
+        MPU_Set_Protection(0x20000000, MPU_REGION_SIZE_1MB, MPU_REGION_NUMBER0, MPU_REGION_FULL_ACCESS);
         MPU_Set_Protection(0x20010000, MPU_REGION_SIZE_1KB, MPU_REGION_NUMBER1, MPU_REGION_NO_ACCESS);
         //
     }

--- a/components/lwp/arch/arm/cortex-m4/lwp_rvds.S
+++ b/components/lwp/arch/arm/cortex-m4/lwp_rvds.S
@@ -319,15 +319,15 @@ svc_exit     PROC
 
     MSR     PSP, R3                 ; restore app stack pointer
     ; restore to PSP & thread-unprivilege mode.;进入线程非特权模式,在核心中测试时，切勿进入，否则会发生无法切换线程的错误。
-    MRS     R2, CONTROL
-    ORR     R2, R2, #0x03
-    MSR     CONTROL, R2
+    ;MRS     R2, CONTROL
+    ;ORR     R2, R2, #0x03
+    ;MSR     CONTROL, R2
 
     ; return to lwp.<User App>
-    ORR     R1, R1, #0x01           ; only Thumb-mode.
-    BX      R1                      ; return to user app.
+    ;ORR     R1, R1, #0x01           ; only Thumb-mode.
+    ;BX      R1                      ; return to user app.
 
-    ;B       return_user_app
+    B       return_user_app
 
     ENDP
 


### PR DESCRIPTION
## 错误现象
![image](https://user-images.githubusercontent.com/30559085/98943443-76fbce00-252a-11eb-9e7a-3715d61bdab3.png)
此错误发生在，syscall执行printf后，回到svc_exit中，切换MODE后，执行ORR附近发生错误。
```
svc_exit     PROC
    EXPORT svc_exit

    ; get user SP.
    PUSH    {R0}                    ; push result to SP.
    BL      lwt_get_kernel_sp
    LDR     R3, [R0, #-4]           ; currentSP - 4 = app SP
    POP     {R0}

    LDR     LR, [R3, #20]
    LDR     R1, [R3, #24]           ; load pc <restore? user App PC>
    ADD     R3, #32                 ; exception_stack_frame size

    MSR     PSP, R3                 ; restore app stack pointer
    ; restore to PSP & thread-unprivilege mode.;进入线程非特权模式,在核心中测试时，切勿进入，否则会发生无法切换线程的错误。
    MRS     R2, CONTROL
    ORR     R2, R2, #0x03
    MSR     CONTROL, R2

    ; return to lwp.<User App>
    ORR     R1, R1, #0x01           ; only Thumb-mode.
    BX      R1                      ; return to user app.

    ;B       return_user_app

    ENDP
```
## 修复后演示
![image](https://user-images.githubusercontent.com/30559085/98943628-c215e100-252a-11eb-94c7-58eea59b197d.png)
